### PR TITLE
Aria hidden is now correctly treated as an attribute instead of a style

### DIFF
--- a/src/vue-input-autowidth.js
+++ b/src/vue-input-autowidth.js
@@ -35,9 +35,9 @@ export default {
       fontVariantNumeric: styles.getPropertyValue("font-variant-numeric"),
       letterSpacing: styles.getPropertyValue("letter-spacing"),
       padding: styles.getPropertyValue("padding"),
-      textTransform: styles.getPropertyValue("text-transform"),
-      ariaHidden: true
+      textTransform: styles.getPropertyValue("text-transform")
     });
+    el.mirror.setAttribute("aria-hidden", "true");
     document.body.appendChild(el.mirror);
     checkWidth(el, binding);
   },


### PR DESCRIPTION
`aria-hidden` was incorrectly treated as a style. But it is an attribute. Therefore screen readers still read the mirror span.

This pull request fixes this problem.

Now screen readers correctly ignore the span. I've tested the behaviour with NVDA.

regards!