### PR TITLE
Adds 'binding' to the unbind hook

### DIFF
--- a/src/vue-input-autowidth.js
+++ b/src/vue-input-autowidth.js
@@ -48,7 +48,7 @@ export default {
   componentUpdated: function(el, binding) {
     checkWidth(el, binding);
   },
-  unbind: function(el) {
+  unbind: function(el, binding) {
     document.body.removeChild(el.mirror);
     el.removeEventListener("input", checkWidth.bind(null, el, binding));
   }


### PR DESCRIPTION
Linter was giving me an error because the `binding` variable doesn't exists on that context.