### PR TITLE
Add exports.types to tsconfig.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "module": "./dist/vue-input-autowidth.es.js",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/vue-input-autowidth.es.js",
       "require": "./dist/vue-input-autowidth.umd.js"
     }


### PR DESCRIPTION
This fixes the import error when using `"moduleResolution": "bundler"` (now the default in Vue)

See https://github.com/vuejs/tsconfig#migrating-from-typescript--50